### PR TITLE
RdfNamespace.php: make properties protected to enable usage in subclasses

### DIFF
--- a/src/rdfHelpers/RdfNamespace.php
+++ b/src/rdfHelpers/RdfNamespace.php
@@ -45,7 +45,7 @@ abstract class RdfNamespace implements \rdfInterface\RdfNamespaceInterface {
 
     abstract protected function getNamedNode(string $iri): NamedNode;
 
-    private int $n = 0;
+    protected int $n = 0;
 
     /**
      *

--- a/src/rdfHelpers/RdfNamespace.php
+++ b/src/rdfHelpers/RdfNamespace.php
@@ -51,7 +51,7 @@ abstract class RdfNamespace implements \rdfInterface\RdfNamespaceInterface {
      *
      * @var array<string, string>
      */
-    private array $namespaces = [];
+    protected array $namespaces = [];
 
     public function add(string $iriPrefix, ?string $shortName = null): string {
         $key = array_search($iriPrefix, $this->namespaces);


### PR DESCRIPTION
This change makes handling code in a sub class more reliable because one doesn't have to think about re-adding existing properties.